### PR TITLE
Update ecwid-shopping-cart.php

### DIFF
--- a/ecwid-shopping-cart.php
+++ b/ecwid-shopping-cart.php
@@ -2988,7 +2988,6 @@ function ecwid_update_store_id( $new_store_id ) {
 
 function ecwid_is_paid_account()
 {
-    return false;
 	if ( Ecwid_Api_V3::is_available() ) {
 		$api = new Ecwid_Api_V3();
 


### PR DESCRIPTION
Fix the function ecwid_is_paid_account() in ecwid_shopping_cart.php. 

The `return false;` was preventing the check on a paid account. 
Therefor disabling multiple function in the plugin like SSO connection.